### PR TITLE
Update to regex-automata v0.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,12 @@ jobs:
       - name: Run tests
         uses: actions-rs/cargo@v1
         with:
-          command: build
+          command: test
+      - name: Run tests (unicode)
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --features unicode
 
   clippy_check:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matchers"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Eliza Weisman <eliza@buoyant.io>"]
 edition = "2018"
 license = "MIT"
@@ -18,4 +18,7 @@ keywords = ["regex", "match", "pattern", "streaming"]
 maintenance = { status = "experimental" }
 
 [dependencies]
-regex-automata = "0.1"
+regex-automata = { version = "0.4", default-features = false, features = ["syntax", "dfa-build", "dfa-search"] }
+
+[features]
+unicode = ["regex-automata/unicode"]


### PR DESCRIPTION
This updates to use regex-automata v0.4, bumping the crate to 0.2 since regex-automata is a public dependency of the crate. All tests in this crate continue to pass.

This removes the `ToMatcher` trait in favor of directly using the upstream Automaton trait, it didn't seem like that trait was really being used. As of the current PR, there's no way to construct Patterns with the sparse DFA (this seems to have been true of the prior version of the crate too), but all the functionality is generic over [regex_automata::Automaton](https://docs.rs/regex-automata/latest/regex_automata/dfa/trait.Automaton.html), so just adding constructs for the lazy DFA 
would be enough to make it possible to use.

This also reduces the enabled features on regex-automata to not include unicode features. It's not obvious that downstream crates (in particular tracing-subscriber) want to pay the binary size cost for having those enabled in env-filter regexes, and this leaves the choice up to them.

Resolves #3.