### PR TITLE
ensure `BuildError` impls `std::error::Error`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ keywords = ["regex", "match", "pattern", "streaming"]
 maintenance = { status = "experimental" }
 
 [dependencies]
-regex-automata = { version = "0.4", default-features = false, features = ["syntax", "dfa-build", "dfa-search"] }
+regex-automata = { version = "0.4", default-features = false, features = ["std", "syntax", "dfa-build", "dfa-search"] }
 
 [features]
 unicode = ["regex-automata/unicode"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -321,6 +321,14 @@ impl<A: Automaton> io::Write for Matcher<A> {
     }
 }
 
+const _: () = {
+    fn assert_is_std_error<T: std::error::Error>() {}
+
+    fn assert_build_error_is_std_error() {
+        assert_is_std_error::<BuildError>();
+    }
+};
+
 #[cfg(test)]
 mod test {
     use super::*;


### PR DESCRIPTION
Some usage in tracing expects this impl, as mentioned here: <https://github.com/tokio-rs/tracing/pull/3033#pullrequestreview-2190382467> It's provided when `regex-automata` has its `std` feature enabled. As `matchers` uses `std` itself, no reason not to allow `regex-automata` to do so also. Seems like the most straightforward way to address the problem:

* avoids the need to create a wrapper type.
* less fragile than bumping `tracing-subscriber`'s `regex` dependency to 1.9.0 and hoping that all semver-compatible versions will continue depending on `regex-automata` with this `std` feature enabled.